### PR TITLE
Strip whitespace from values

### DIFF
--- a/gpdconfig/wincontrols/hardware.py
+++ b/gpdconfig/wincontrols/hardware.py
@@ -207,6 +207,7 @@ class WinControls():
             key, value = line.split("=")
 
             key = key.strip().lower()
+            value = value.strip()
 
             if not key in self.field:
                 raise RuntimeError("Invalid config key: %s" % key)


### PR DESCRIPTION
I was getting errors with `gpdconfig -s config.txt` with it taking the newline as the `value` and erroring out. This PR will adress both this case and the case where users add any extra whitespace after the `=` or after the value itself.